### PR TITLE
修复新增时无法自动设置一对多关系问题

### DIFF
--- a/addon/adapters/wildember.js
+++ b/addon/adapters/wildember.js
@@ -51,7 +51,7 @@ export default DS.Adapter.extend(Waitable, {
   /**
    * 初始化，并获取野狗的连接
    */
-  init(application) {
+  init(/*application*/) {
     this._super.apply(this, arguments);
     // wilddogConfig会在子类中被赋值
     let wilddogConfig = this.get('wilddogConfig');
@@ -433,27 +433,27 @@ export default DS.Adapter.extend(Waitable, {
       includeId: (lastPiece !== snapshot.id) // record has no wilddog `key` in path
     });
     const serializer = store.serializerFor(typeClass.modelName);
-
+    debugger;
     return new Promise((resolve, reject) => {
       var relationshipsToSave = [];
       // first we remove all relationships data from the serialized record, we backup the
       // removed data so that we can save it at a later stage.
       snapshot.record.eachRelationship((key, relationship) => {
-      const relationshipKey = serializer.keyForRelationship(key);
-      const data = serializedRecord[relationshipKey];
-      const isEmbedded = this.isRelationshipEmbedded(store, typeClass.modelName, relationship);
-      const hasMany = relationship.kind === 'hasMany';
-      if (hasMany || isEmbedded) {
-          if (!Ember.isNone(data)) {
-            relationshipsToSave.push({
-              data:data,
-              relationship:relationship,
-              isEmbedded:isEmbedded,
-              hasMany:hasMany
-            });
+          const relationshipKey = serializer.keyForRelationship(key);
+          const data = serializedRecord[relationshipKey];
+          const isEmbedded = this.isRelationshipEmbedded(store, typeClass.modelName, relationship);
+          const hasMany = relationship.kind === 'hasMany';
+          if (hasMany || isEmbedded) {
+              if (!Ember.isNone(data)) {
+                relationshipsToSave.push({
+                  data:data,
+                  relationship:relationship,
+                  isEmbedded:isEmbedded,
+                  hasMany:hasMany
+                });
+              }
+              delete serializedRecord[relationshipKey];
           }
-          delete serializedRecord[relationshipKey];
-        }
       });
       var reportError = (errors) => {
         var error = new Error(`Some errors were encountered while saving ${typeClass} ${snapshot.id}`);
@@ -694,7 +694,7 @@ export default DS.Adapter.extend(Waitable, {
     }
 
     var embeddingParent = this.getFirstEmbeddingParent(record);
-
+debugger;
     if (embeddingParent) {
       var { record: parent, relationship } = embeddingParent;
       const embeddedKey = parent.store.serializerFor(parent.modelName).keyForRelationship(relationship.key);

--- a/addon/initializers/application.js
+++ b/addon/initializers/application.js
@@ -5,7 +5,13 @@ import WildemberAdapter from '../adapters/wildember';
 import WildemberSerializer from '../serializers/wildember';
 import forEach from 'lodash/collection/forEach';
 
-export function initialize(application) {
+export function initialize(/*application*/) {
+
+
+    let application = arguments[1] || arguments[0];
+    // 千万千万别忘记注册，否则在application中不起作用
+    application.register('adapter:-wildember', WildemberAdapter);
+    application.register('serializer:-wildember', WildemberSerializer);
 
   // Monkeypatch the store until ED gives us a good way to listen to push events
   if (!DS.Store.prototype._emberfirePatched) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wildember",
   "description": "一个方便、快捷连接野狗实时服务适配器。",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "author": "ubuntuvim (https://github.com/ubuntuvim/)",
   "homepage": "https://wildember.ddlisting.com",
   "directories": {


### PR DESCRIPTION
由于没有正确注册`WildemberSeriazer`导致无法自动序列化`hasMany`关系，保存一对多关系时无法在一的一方新增一个关系数组。

```javascript
export function initialize(/*application*/) {


    let application = arguments[1] || arguments[0];
    // 千万千万别忘记注册，否则在application中不起作用
    application.register('adapter:-wildember', WildemberAdapter);
    application.register('serializer:-wildember', WildemberSerializer);

// ……其他代码照旧
```